### PR TITLE
Move ratings into state machine

### DIFF
--- a/Podest.xcodeproj/project.pbxproj
+++ b/Podest.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4C02C29A2247544C00C7D647 /* StoreState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C02C2992247544C00C7D647 /* StoreState.swift */; };
 		4C02C29B2247544C00C7D647 /* StoreState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C02C2992247544C00C7D647 /* StoreState.swift */; };
 		4C03FE2F22EAB96600A2C3B6 /* ReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03FE2E22EAB96600A2C3B6 /* ReviewRequester.swift */; };
+		4C03FE3022EAF16A00A2C3B6 /* ReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03FE2E22EAB96600A2C3B6 /* ReviewRequester.swift */; };
 		4C07C97621EB0C9600ED8AB0 /* StoreLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C07C97521EB0C9600ED8AB0 /* StoreLayout.swift */; };
 		4C07C97721EB13BB00ED8AB0 /* MessageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C776B1F2084722C00A055CD /* MessageCollectionViewCell.swift */; };
 		4C07C97A21EBA69200ED8AB0 /* ArticleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C07C97821EBA69200ED8AB0 /* ArticleCollectionViewCell.swift */; };
@@ -1271,6 +1272,7 @@
 				4C72D43B22716613008F8B96 /* strings.swift in Sources */,
 				4C72D43222702B16008F8B96 /* ListOperation.swift in Sources */,
 				4C010A262101D7070006CB53 /* store.swift in Sources */,
+				4C03FE3022EAF16A00A2C3B6 /* ReviewRequester.swift in Sources */,
 				4C010A272101D7070006CB53 /* StoreFSM.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Podest.xcodeproj/project.pbxproj
+++ b/Podest.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4C010A272101D7070006CB53 /* StoreFSM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C175AA5208AFA26003071CA /* StoreFSM.swift */; };
 		4C02C29A2247544C00C7D647 /* StoreState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C02C2992247544C00C7D647 /* StoreState.swift */; };
 		4C02C29B2247544C00C7D647 /* StoreState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C02C2992247544C00C7D647 /* StoreState.swift */; };
+		4C03FE2F22EAB96600A2C3B6 /* ReviewRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03FE2E22EAB96600A2C3B6 /* ReviewRequester.swift */; };
 		4C07C97621EB0C9600ED8AB0 /* StoreLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C07C97521EB0C9600ED8AB0 /* StoreLayout.swift */; };
 		4C07C97721EB13BB00ED8AB0 /* MessageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C776B1F2084722C00A055CD /* MessageCollectionViewCell.swift */; };
 		4C07C97A21EBA69200ED8AB0 /* ArticleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C07C97821EBA69200ED8AB0 /* ArticleCollectionViewCell.swift */; };
@@ -280,6 +281,7 @@
 		4C010A1E2101D6E90006CB53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4C010A2A2101DBB00006CB53 /* FeedKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FeedKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C02C2992247544C00C7D647 /* StoreState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreState.swift; sourceTree = "<group>"; };
+		4C03FE2E22EAB96600A2C3B6 /* ReviewRequester.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewRequester.swift; sourceTree = "<group>"; };
 		4C07C97521EB0C9600ED8AB0 /* StoreLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreLayout.swift; sourceTree = "<group>"; };
 		4C07C97821EBA69200ED8AB0 /* ArticleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleCollectionViewCell.swift; sourceTree = "<group>"; };
 		4C07C97921EBA69200ED8AB0 /* ArticleCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ArticleCollectionViewCell.xib; sourceTree = "<group>"; };
@@ -683,6 +685,7 @@
 			children = (
 				4CCBF20920805C6500A7359F /* store.swift */,
 				4C175AA5208AFA26003071CA /* StoreFSM.swift */,
+				4C03FE2E22EAB96600A2C3B6 /* ReviewRequester.swift */,
 				4C02C2992247544C00C7D647 /* StoreState.swift */,
 				4C1F57A620810D850067AB7C /* ProductsViewController.swift */,
 				4C07C97521EB0C9600ED8AB0 /* StoreLayout.swift */,
@@ -1365,6 +1368,7 @@
 				4C8B375E22A0ED280004FD89 /* TwoPlusLayout.swift in Sources */,
 				4C8B374822A0ED280004FD89 /* ControlsCell.swift in Sources */,
 				4C351CD11A7F5B7F00C5C88C /* SearchResultsDataSource.swift in Sources */,
+				4C03FE2F22EAB96600A2C3B6 /* ReviewRequester.swift in Sources */,
 				4E65BB2E1F138BA500C7F1A3 /* UserSyncing.swift in Sources */,
 				4CEC436521D68BD50097FFA7 /* MessageTableViewCell.swift in Sources */,
 				4C776B212084722C00A055CD /* MessageCollectionViewCell.swift in Sources */,

--- a/Podest.xcodeproj/xcshareddata/xcschemes/Podest.xcscheme
+++ b/Podest.xcodeproj/xcshareddata/xcschemes/Podest.xcscheme
@@ -98,7 +98,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-ink.codes.podest.noDownloading"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-ink.codes.podest.allButUpsideDown"

--- a/Podest/queue/QueueViewController.swift
+++ b/Podest/queue/QueueViewController.swift
@@ -249,7 +249,7 @@ extension QueueViewController {
 
   override func viewDidAppear(_ animated: Bool) {
     if searchProxy.isSearchDismissed {
-      Podest.store.requestReview()
+      Podest.store.considerReview()
     }
 
     searchProxy.deselect(animated)

--- a/Podest/store/ReviewRequester.swift
+++ b/Podest/store/ReviewRequester.swift
@@ -97,7 +97,6 @@ class ReviewRequester {
   @discardableResult
   func setReviewTimeout(reviewBlock: @escaping () -> Void) -> Bool {
     precondition(!invalidated)
-    dispatchPrecondition(condition: .onQueue(.main))
     
     rateIncentiveTimeout = nil
     
@@ -129,7 +128,6 @@ class ReviewRequester {
   }
   
   func cancelReview(resetting: Bool) {
-    dispatchPrecondition(condition: .onQueue(.main))
     precondition(!invalidated)
     
     rateIncentiveTimeout = nil

--- a/Podest/store/ReviewRequester.swift
+++ b/Podest/store/ReviewRequester.swift
@@ -33,8 +33,6 @@ class ReviewRequester {
   }
   
   /// The timer triggering rating requests.
-  /// 
-  /// Setting cancel old timer.
   private var rateIncentiveTimeout: DispatchSourceTimer? {
     willSet {
       os_log("setting rate incentive timeout: %@", 
@@ -100,17 +98,17 @@ class ReviewRequester {
     
     rateIncentiveTimeout = nil
     
-    guard rateIncentiveCountdown >= 0 else {
-      os_log("not setting review timeout: rating disabled", log: log)
+    guard rateIncentiveCountdown >= 0, isTime else {
+      os_log("not setting review timeout", log: log)
       return false
     }
     
     rateIncentiveCountdown -= 1
     
-    guard rateIncentiveCountdown == 0, isTime else {
-        os_log("** not setting review timeout: too soon", log: log, type: .debug)
-        
-        return false
+    os_log("** countdown: %i", log: log, type: .debug, rateIncentiveCountdown)
+    
+    guard rateIncentiveCountdown == 0 else {
+      return false
     }
     
     rateIncentiveCountdown = ReviewRequester.rateIncentiveLength

--- a/Podest/store/ReviewRequester.swift
+++ b/Podest/store/ReviewRequester.swift
@@ -41,8 +41,8 @@ class ReviewRequester {
     }
   }
   
-  /// Counting down from five for simple activity tracking.
-  private static let rateIncentiveLength = 5
+  /// Counting down to zero before requesting a rating.
+  private static let rateIncentiveLength = 6
   
   /// Countdown to trigger ratings. Set to -1 to deactivate ratings.
   private var rateIncentiveCountdown = rateIncentiveLength {

--- a/Podest/store/ReviewRequester.swift
+++ b/Podest/store/ReviewRequester.swift
@@ -1,0 +1,120 @@
+//
+//  ReviewRequester.swift
+//  Podest
+//
+//  Created by Michael Nisi on 12.07.19.
+//  Copyright © 2019 Michael Nisi. All rights reserved.
+//
+
+import Foundation
+import StoreKit
+import os.log
+
+/// Requests users for feedback.
+class ReviewRequester {
+
+  private let version: BuildVersion
+  
+  private let unsealedTime: TimeInterval
+  
+  private let log: OSLog 
+  
+  init(version: BuildVersion, unsealedTime: TimeInterval, log: OSLog) {
+    self.version = version
+    self.unsealedTime = unsealedTime
+    self.log = log
+  }
+  
+  /// The timeout triggering rating requests.
+  private var rateIncentiveTimeout: DispatchSourceTimer? {
+    willSet {
+      os_log("setting rate incentive timeout: %@", 
+             log: log, type: .debug, String(describing: newValue))
+      rateIncentiveTimeout?.cancel()
+    }
+  }
+  
+  /// The `rateIncentiveCountdown`starts with this value.
+  private static var rateIncentiveLength = 5
+  
+  /// Countdown to trigger ratings. Set to -1 to deactivate ratings.
+  private var rateIncentiveCountdown = rateIncentiveLength {
+    didSet {
+      guard rateIncentiveCountdown >= 0 else {
+        return os_log("rating disabled", log: log, type: .info)
+      }
+      
+      os_log("rate incentive threshold: %{public}i",
+             log: log, type: .debug, rateIncentiveCountdown)
+    }
+  }
+  
+  func requestReview() {
+    let build = version.build
+    
+    DispatchQueue.main.async {
+      let key = UserDefaults.lastVersionPromptedForReviewKey
+      
+      UserDefaults.standard.set(build, forKey: key)
+      SKStoreReviewController.requestReview()
+    }
+  }
+  
+  /// Waits two seconds before triggering a `.review` event, giving us a chance
+  /// to cancel (this timeout) when the context changes and a review is not
+  /// appropriate any longer. Of course, an existing timeout gets cancelled. 
+  /// 
+  /// Does nothing within three days of first launch.
+  /// 
+  /// Asking for ratings or reviews is only OK while users are idle for a moment
+  /// after they have been active. All other times can be considered harmful.
+  /// People hate getting interrupted.
+  func setReviewTimeout(reviewBlock: @escaping () -> Void) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    
+    rateIncentiveTimeout = nil
+    
+    guard rateIncentiveCountdown >= 0 else {
+      os_log("not setting review timeout: rating disabled", log: log)
+      return
+    }
+    
+    rateIncentiveCountdown -= 1
+    
+    guard rateIncentiveCountdown == 0, 
+      Date().timeIntervalSince1970 - unsealedTime > 3600 * 24 * 3 else {
+        os_log("** not setting review timeout: too soon", log: log, type: .debug)
+        
+        return
+    }
+    
+    rateIncentiveCountdown = ReviewRequester.rateIncentiveLength
+    
+    guard UserDefaults.standard.lastVersionPromptedForReview != version.build else {
+      rateIncentiveCountdown = -1
+  
+      return
+    }
+    
+    rateIncentiveTimeout = setTimeout(delay: .seconds(2), queue: .main, handler: reviewBlock)
+  }
+  
+  func cancelReview(resetting: Bool) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    
+    rateIncentiveTimeout = nil
+    
+    if resetting {
+      rateIncentiveCountdown = ReviewRequester.rateIncentiveLength
+    }
+  }
+  
+  func cancelReview() {
+    cancelReview(resetting: false)
+  }
+  
+  func disable() {
+    rateIncentiveTimeout = nil
+    rateIncentiveCountdown = -1
+  }
+}

--- a/Podest/store/ReviewRequester.swift
+++ b/Podest/store/ReviewRequester.swift
@@ -10,7 +10,7 @@ import Foundation
 import StoreKit
 import os.log
 
-/// Considerately prompts users to leave a rating or a review on the App Store.
+/// Considerately prompts users for a rating or a review on the App Store.
 class ReviewRequester {
 
   private let version: BuildVersion

--- a/Podest/store/ReviewRequester.swift
+++ b/Podest/store/ReviewRequester.swift
@@ -105,7 +105,7 @@ class ReviewRequester {
     
     rateIncentiveCountdown -= 1
     
-    os_log("** countdown: %i", log: log, type: .debug, rateIncentiveCountdown)
+    os_log("countdown: %i", log: log, type: .debug, rateIncentiveCountdown)
     
     guard rateIncentiveCountdown == 0 else {
       return false

--- a/Podest/store/StoreFSM.swift
+++ b/Podest/store/StoreFSM.swift
@@ -169,11 +169,6 @@ final class StoreFSM: NSObject {
   
   // MARK: Reachability
 
-  /// Returns `true` if the App Store at `host` is reachable or else installs
-  /// a callback and returns `falls`. This method uses `Ola` for reachability
-  /// checking. Set `host` to `localhost` during testing—that should be fine.
-  /// Replacing this with a block would be better:
-  /// (
   private func isReachable() -> Bool {
     return subscriberDelegate?.reach() ?? false
   }
@@ -225,6 +220,7 @@ final class StoreFSM: NSObject {
 
     let req = SKProductsRequest(productIdentifiers: self.productIdentifiers)
     req.delegate = self
+    
     req.start()
     
     request = req

--- a/Podest/store/StoreFSM.swift
+++ b/Podest/store/StoreFSM.swift
@@ -66,7 +66,6 @@ extension StoreEvent: CustomStringConvertible {
       return "StoreEvent: cancelReview"
     }
   }
-  
 }
 
 private class DefaultPaymentQueue: Paying {}

--- a/Podest/store/store.swift
+++ b/Podest/store/store.swift
@@ -45,7 +45,6 @@ struct PodestReceipt: Codable {
     self.transactionIdentifier = transactionIdentifier
     self.transactionDate = transactionDate
   }
-
 }
 
 /// Trade representative contact information.
@@ -86,7 +85,6 @@ extension Paying {
   func remove(_ observer: SKPaymentTransactionObserver) {
     SKPaymentQueue.default().remove(observer)
   }
-  
 }
 
 // MARK: - API
@@ -148,7 +146,6 @@ enum ShoppingError: Error {
       }
     }
   }
-
 }
 
 /// Get notified when accessiblity to the store changes.
@@ -166,7 +163,6 @@ protocol StoreAccessDelegate: class {
 
   /// Receives expiration updates.
   func store(_ store: Shopping, isExpired: Bool)
-
 }
 
 /// Receives shopping events.
@@ -187,14 +183,13 @@ protocol StoreDelegate: class {
 
   /// Display an error message after this callback.
   func store(_ store: Shopping, error: ShoppingError)
-  
 }
 
 /// Ask users for rating and reviews.
 protocol Rating {
 
   /// Requests user to rate the app if appropriate.
-  func requestReview()
+  func considerReview()
 
   /// Cancels previous review request, `resetting` the cycle to defer the next.
   ///
@@ -205,7 +200,6 @@ protocol Rating {
 
   /// Cancels previous review request.
   func cancelReview()
-
 }
 
 /// Checking user status.
@@ -216,7 +210,6 @@ protocol Expiring {
   ///
   /// Might modify internal state or call delegates.
   func isExpired() -> Bool
-
 }
 
 /// A set of methods to offer in-app purchases.
@@ -246,6 +239,5 @@ protocol Shopping: SKPaymentTransactionObserver, Rating, Expiring {
   
   /// Notifies the store that the App Store is reachable.
   func online()
-  
 }
 


### PR DESCRIPTION
These changes move ratings and review incentive triggering and handling into the store state machine for better control and timing, also with respect to reachability.